### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test/
+.github/
+examples/
+.eslintrc
+README.md


### PR DESCRIPTION
This package publishes non-code files to npmjs.com. To simplify the published package and reduce the size, `.npmignore` will prevent build dependencies from being included.

For example, contents of the current (`2.2.2`) published tarball.

<img width="1638" height="1457" alt="image" src="https://github.com/user-attachments/assets/92431071-2a03-42d4-a59e-77c47fc94b86" />

I leave it as an open question if the change log should be included in the published code (does anyone read this file inside `node_modules/` ?)
